### PR TITLE
Pass navigation control options

### DIFF
--- a/src/components/Mapbox.vue
+++ b/src/components/Mapbox.vue
@@ -308,7 +308,7 @@
 			addControls (map) {
 				//Nav Control
 				if (this.navControl.show) {
-					const nav = new mapboxgl.NavigationControl();
+					const nav = new mapboxgl.NavigationControl(this.navControl.options);
 					map.addControl(nav, this.navControl.position);
 				}
 


### PR DESCRIPTION
I needed to pass `showCompass: false`.

This PR enable that i.e passing navigation control options.

https://www.mapbox.com/mapbox-gl-js/api/#navigationcontrol